### PR TITLE
fix: remove redundant package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "nextjspage",
       "version": "0.1.0",
       "dependencies": {
-        "@next/font": "^13.5.5",
         "@react-native-community/blur": "^4.3.2",
         "next": "latest",
         "react": "latest",
@@ -2559,11 +2558,6 @@
       "dependencies": {
         "glob": "7.1.7"
       }
-    },
-    "node_modules/@next/font": {
-      "version": "13.5.5",
-      "resolved": "https://registry.npmjs.org/@next/font/-/font-13.5.5.tgz",
-      "integrity": "sha512-X1BwoqJ/ua9NLCFsWAZ3n3Q74tkHbbqf4YkI9VRn/InqUkY3TnyPao/aSCdJ5w4aWUZBZlOjZJiQnD6JnOCoMw=="
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "13.5.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@next/font": "^13.5.5",
     "@react-native-community/blur": "^4.3.2",
     "next": "latest",
     "react": "latest",


### PR DESCRIPTION
From version 13.2 onward, next/font has been built into Next.js, making the @next/font package redundant. The @next/font package will be completely removed in Next.js 14.

